### PR TITLE
BAU Update to use the latests payments slo

### DIFF
--- a/index.html
+++ b/index.html
@@ -24,7 +24,7 @@
       </div>
       <div class="tc pa4">
         <h3 class="f1 ma0 pa4">Whether we're above or below our target for successful user payments</h3>
-        <iframe class="w-100 h-100" frameborder="0" scrolling="no" src="https://gds.splunkcloud.com/en-GB/embed?s=%2FservicesNS%2Fnobody%2Fgds-004-pay%2Fsaved%2Fsearches%2FPayment%2520journey%2520SLO%2520v4&oid=9AQ0OBPfxiC5p6okG9dQ74eTntFeenElA__fz1hi65Hufxlc3sa25bSNYdFh_%5EOkkUdHAcYhNuYSqJzgca3XC%5E353Ks7nAUB00erAIfjYsPuS4DUaERReL_7BRMaW12v7WZSYJy5LIuqCIzejLqqoEP7c2byhD_lGcLeGeZ9NLuM_V%5E_PHMcDe08T9FzXgX4LXDQWA3NvqED"></iframe>
+        <iframe class="w-100 h-100" frameborder="0" scrolling="no" src="https://gds.splunkcloud.com/en-GB/embed?s=%2FservicesNS%2Fnobody%2Fgds-004-pay%2Fsaved%2Fsearches%2FPayment%2520journey%2520SLO%2520v5&oid=AsorOAXXEkPCk7vBqWU7ZKc12yzEsxXAvXV1wtanerxT0kEJQN%5EEu5SGxeep%5EK4aEtufZ5UNF8ekv2MbDfZHgSFUYCfHkk%5ErsrHwX9BXGKdiSqdfeA5p107OyFvVsjXi1axNxe9hhh9N%5EpXXOyjOPAoU%5EjMk_1ooxAjtkRjjsGdgl12OmLZyq6ODNcYMhzdbLbO8knah8TjjJx0"></iframe>
       </div>
     </div>
   </body>


### PR DESCRIPTION
The payments slo was updated to remove duplicate payment ids with the
same `to_state` to work around the `expire-changes-sweeping` job
attempting to expire the same charges multiple times; it has now been
fixed.